### PR TITLE
Update zcap id invocation target

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
   - **BREAKING**: Use Ed25519 Verification Key 2020 v3.
   - **BREAKING**: Use Ed25519 Signature 2020.
   - **BREAKING**: Remove jws from proofs.
+  - **BREAKING**: Change capability ids to root zcaps.
+  - **BREAKING**: Use attenuated invocationTargets.
   - Use jsigs v 9.
   - Use `@digitalbazaar/zcapld` over `ocapld`.
 

--- a/lib/operation-generator.js
+++ b/lib/operation-generator.js
@@ -148,7 +148,6 @@ exports.createOperation = async ({mode, hostname}) => {
     purpose: 'capabilityInvocation'
   });
   const signedOperation = await jsigs.sign(operation, {
-    compactProof: false,
     documentLoader: v1.documentLoader,
     suite: new Ed25519Signature2020({key: capabilityInvocationKey}),
     purpose: new CapabilityInvocation({

--- a/lib/operation-generator.js
+++ b/lib/operation-generator.js
@@ -152,7 +152,7 @@ exports.createOperation = async ({mode, hostname}) => {
     documentLoader: v1.documentLoader,
     suite: new Ed25519Signature2020({key: capabilityInvocationKey}),
     purpose: new CapabilityInvocation({
-      capability: didDocument.id,
+      capability: `urn:zcap:root:${encodeURIComponent(didDocument.id)}`,
       invocationTarget: operation.record.id,
       capabilityAction: 'write'
     })

--- a/lib/operation-generator.js
+++ b/lib/operation-generator.js
@@ -123,6 +123,8 @@ exports.sendOperation = async ({mode, hostname, operation}) => {
   }
 };
 
+const ledgerId = 'did:v1:uuid:c37e914a-1e2a-4d59-9668-ee93458fd19a';
+
 exports.createOperation = async ({mode, hostname}) => {
   const veresDriver = await _getDriver({mode, hostname});
   const {didDocument, methodFor} = await veresDriver.generate({});
@@ -132,10 +134,9 @@ exports.createOperation = async ({mode, hostname}) => {
   operation.proof = {
     type: 'Ed25519Signature2020',
     created: '2019-01-10T23:10:25Z',
-    capability: 'did:v1:uuid:c37e914a-1e2a-4d59-9668-ee93458fd19a',
+    capability: `urn:zcap:root:${encodeURIComponent(ledgerId)}`,
     capabilityAction: 'write',
-    invocationTarget:
-          'did:v1:nym:z6Mkogv718iDZqyoTmPKagKcG2VBXXz6w4xau8fL5jjB948r',
+    invocationTarget: `${ledgerId}/records`,
     proofValue: 'z3t9it5yhFHkqWnHKMQ2DWVj7aHDN37f95UzhQYQGYd9LyTSGzufCiTwDWN' +
                 'fCdxQA9ZHcTTVAhHwoAji2AJnk2E6',
     proofPurpose: 'capabilityInvocation',


### PR DESCRIPTION
EDIT: it appears this is good to go and needs a major release CHANGELOG.

Related PRs for attenuated invocationTargets and dynamic root zcaps:
https://github.com/veres-one/veres-one-validator/pull/42
https://github.com/veres-one/veres-one-validator/pull/41
https://github.com/digitalbazaar/did-bench-cli/pull/12
https://github.com/veres-one/veres-one-maintainer-cli/pull/3
https://github.com/veres-one/did-veres-one/pull/73
https://github.com/veres-one/veres-one/pull/56

Test:
This PR was tested with 4 nodes with a witnessPool document written using the maintainer cli.
`did-bench-cli` managed to write didDocuments to the ledger with no issues.
The test script used to test this PR is available via email or gist.